### PR TITLE
当输入的css文件内容为空时，该插件未做处理，导致报错

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ module.exports = function(opt) {
     var reg=/([^\{]*)\{([^\}]*)\}/g;
     var array_style=s_file.match(reg);
     var new_array=[];
+// 源css文件内容为空时，直接返回
     if(!array_syle) return callback(null,file);
     array_style.forEach(function(value){
       if(ignore_selector.indexOf(value.split('{')[0].replace(/(^\s*)|(\s*$)/g,'')) > -1) {

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = function(opt) {
     var reg=/([^\{]*)\{([^\}]*)\}/g;
     var array_style=s_file.match(reg);
     var new_array=[];
-
+    if(!array_syle) return callback(null,file);
     array_style.forEach(function(value){
       if(ignore_selector.indexOf(value.split('{')[0].replace(/(^\s*)|(\s*$)/g,'')) > -1) {
       }


### PR DESCRIPTION
通过判断match返回值进行对应处理解决了这个问题